### PR TITLE
move launch files into launch.legacy namespace

### DIFF
--- a/movidius_ncs_launch/launch/ncs_image_launch.py
+++ b/movidius_ncs_launch/launch/ncs_image_launch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from launch.exit_handler import default_exit_handler
+from launch.legacy.exit_handler import default_exit_handler
 from ros2run.api import get_executable_path
 
 

--- a/movidius_ncs_launch/launch/ncs_stream_launch.py
+++ b/movidius_ncs_launch/launch/ncs_stream_launch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from launch.exit_handler import default_exit_handler
+from launch.legacy.exit_handler import default_exit_handler
 from ros2run.api import get_executable_path
 
 


### PR DESCRIPTION
Update project's launch files due to ROS2 core update(PR [#73](https://github.com/ros2/launch/commit/fb6cbe4bd79b494f2ee85808f6a580a1a4b45111))

Signed-off-by: Chao Li <chao1.li@intel.com>