### PR TITLE
change x and y of bounding box to left-top point

### DIFF
--- a/movidius_ncs_example/src/image_detection.cpp
+++ b/movidius_ncs_example/src/image_detection.cpp
@@ -67,15 +67,13 @@ int main(int argc, char ** argv)
         srv->objects.objects_vector[i].roi.x_offset, srv->objects.objects_vector[i].roi.y_offset,
         srv->objects.objects_vector[i].roi.width, srv->objects.objects_vector[i].roi.height);
 
-      int x = srv->objects.objects_vector[i].roi.x_offset;
-      int y = srv->objects.objects_vector[i].roi.y_offset;
+      int xmin = srv->objects.objects_vector[i].roi.x_offset;
+      int ymin = srv->objects.objects_vector[i].roi.y_offset;
       int w = srv->objects.objects_vector[i].roi.width;
       int h = srv->objects.objects_vector[i].roi.height;
 
-      int xmin = ((x - w / 2) > 0) ? (x - w / 2) : 0;
-      int xmax = ((x + w / 2) < width) ? (x + w / 2) : width;
-      int ymin = ((y - h / 2) > 0) ? (y - h / 2) : 0;
-      int ymax = ((y + h / 2) < height) ? (y + h / 2) : height;
+      int xmax = ((xmin + w) < width) ? (xmin + w) : width;
+      int ymax = ((ymin + h) < height) ? (ymin + h) : height;
 
       cv::Point left_top = cv::Point(xmin, ymin);
       cv::Point right_bottom = cv::Point(xmax, ymax);

--- a/movidius_ncs_example/src/stream_detection.cpp
+++ b/movidius_ncs_example/src/stream_detection.cpp
@@ -80,15 +80,13 @@ private:
       std::stringstream ss;
       ss << obj.object.object_name << ": " << obj.object.probability * 100 << '%';
 
-      int x = obj.roi.x_offset;
-      int y = obj.roi.y_offset;
+      int xmin = obj.roi.x_offset;
+      int ymin = obj.roi.y_offset;
       int w = obj.roi.width;
       int h = obj.roi.height;
 
-      int xmin = ((x - w / 2) > 0) ? (x - w / 2) : 0;
-      int xmax = ((x + w / 2) < width) ? (x + w / 2) : width;
-      int ymin = ((y - h / 2) > 0) ? (y - h / 2) : 0;
-      int ymax = ((y + h / 2) < height) ? (y + h / 2) : height;
+      int xmax = ((xmin + w) < width) ? (xmin + w) : width;
+      int ymax = ((ymin + h) < height) ? (ymin + h) : height;
 
       cv::Point left_top = cv::Point(xmin, ymin);
       cv::Point right_bottom = cv::Point(xmax, ymax);

--- a/movidius_ncs_lib/src/result.cpp
+++ b/movidius_ncs_lib/src/result.cpp
@@ -74,14 +74,18 @@ void Result::parseYoloResult(
 
         if (obj_in_bbox.item.probability > prob_threshold) {
           obj_in_bbox.item.category = categories[std::distance(std::begin(probs), max_iter)];
-          obj_in_bbox.bbox.x =
+          int x_center =
             ((result[prob_num + bbox_conf_num + index * 4] + j) / 7.0) * img_width;
-          obj_in_bbox.bbox.y =
+          int y_center =
             ((result[prob_num + bbox_conf_num + index * 4 + 1] + i) / 7.0) * img_height;
           obj_in_bbox.bbox.width = (result[prob_num + bbox_conf_num + index * 4 + 2]) *
             (result[prob_num + bbox_conf_num + index * 4 + 2]) * img_width;
           obj_in_bbox.bbox.height = (result[prob_num + bbox_conf_num + index * 4 + 3]) *
             (result[prob_num + bbox_conf_num + index * 4 + 3]) * img_height;
+          obj_in_bbox.bbox.x = (x_center - 0.5 * obj_in_bbox.bbox.width) < 0 ?
+            0 : (x_center - 0.5 * obj_in_bbox.bbox.width);
+          obj_in_bbox.bbox.y = (y_center - 0.5 * obj_in_bbox.bbox.height) < 0 ?
+            0 : (y_center - 0.5 * obj_in_bbox.bbox.height);
           objs_in_bboxes->push_back(obj_in_bbox);
         }
       }
@@ -127,8 +131,8 @@ void Result::parseSSDResult(
       obj_in_bbox.item.probability = probability;
       obj_in_bbox.bbox.width = xmax - xmin;
       obj_in_bbox.bbox.height = ymax - ymin;
-      obj_in_bbox.bbox.x = xmin + 0.5 * obj_in_bbox.bbox.width;
-      obj_in_bbox.bbox.y = ymin + 0.5 * obj_in_bbox.bbox.height;
+      obj_in_bbox.bbox.x = xmin;
+      obj_in_bbox.bbox.y = ymin;
       objs_in_bboxes->push_back(obj_in_bbox);
     }
   }
@@ -195,18 +199,12 @@ void Result::NMS(ItemInBBoxArrayPtr objs_in_bboxes)
 
 float Result::IOU(ItemInBBox box1, ItemInBBox box2)
 {
-  int xmax = (box1.bbox.x + 0.5 * box1.bbox.width < box2.bbox.x + 0.5 * box2.bbox.width) ?
-    box1.bbox.x + 0.5 * box1.bbox.width :
-    box2.bbox.x + 0.5 * box2.bbox.width;
-  int xmin = (box1.bbox.x - 0.5 * box1.bbox.width > box2.bbox.x - 0.5 * box2.bbox.width) ?
-    box1.bbox.x - 0.5 * box1.bbox.width :
-    box2.bbox.x - 0.5 * box2.bbox.width;
-  int ymax = (box1.bbox.y + 0.5 * box1.bbox.height < box2.bbox.y + 0.5 * box2.bbox.height) ?
-    box1.bbox.y + 0.5 * box1.bbox.height :
-    box2.bbox.y + 0.5 * box2.bbox.height;
-  int ymin = (box1.bbox.y - 0.5 * box1.bbox.height > box2.bbox.y - 0.5 * box2.bbox.height) ?
-    box1.bbox.y - 0.5 * box1.bbox.height :
-    box2.bbox.y - 0.5 * box2.bbox.height;
+  int xmax = (box1.bbox.x + box1.bbox.width < box2.bbox.x + box2.bbox.width) ?
+    box1.bbox.x + box1.bbox.width : box2.bbox.x + box2.bbox.width;
+  int xmin = (box1.bbox.x > box2.bbox.x) ? box1.bbox.x : box2.bbox.x;
+  int ymax = (box1.bbox.y + box1.bbox.height < box2.bbox.y + box2.bbox.height) ?
+    box1.bbox.y + box1.bbox.height : box2.bbox.y + box2.bbox.height;
+  int ymin = (box1.bbox.y > box2.bbox.y) ? box1.bbox.y : box2.bbox.y;
   int inter_w = xmax - xmin;
   int inter_h = ymax - ymin;
   int inter_area = 0;


### PR DESCRIPTION
the previous one is central, but according to the definition of x and y
of ROI, it should be the left-top point.

Signed-off-by: Chao Li <chao1.li@intel.com>